### PR TITLE
Make failure serialization resilient

### DIFF
--- a/taskflow/engines/worker_based/protocol.py
+++ b/taskflow/engines/worker_based/protocol.py
@@ -141,18 +141,6 @@ def build_a_machine(freeze=True):
     return m
 
 
-def failure_to_dict(failure):
-    """Attempts to convert a failure object into a jsonifyable dictionary."""
-    failure_dict = failure.to_dict()
-    try:
-        # it's possible the exc_args can't be serialized as JSON
-        # if that's the case, just get the failure without them
-        jsonutils.dumps(failure_dict)
-        return failure_dict
-    except (TypeError, ValueError):
-        return failure.to_dict(include_args=False)
-
-
 class Capabilities(object):
     """Helpers to dump and load & validate workers capabilities."""
 
@@ -395,13 +383,13 @@ class Request(Message):
         if self._result is not NO_RESULT:
             result = self._result
             if isinstance(result, ft.Failure):
-                request['result'] = ('failure', failure_to_dict(result))
+                request['result'] = ('failure', result.to_dict())
             else:
                 request['result'] = ('success', result)
         if self._failures:
             request['failures'] = {}
             for atom_name, failure in six.iteritems(self._failures):
-                request['failures'][atom_name] = failure_to_dict(failure)
+                request['failures'][atom_name] = failure.to_dict()
         return request
 
     def transition_and_log_error(self, new_state, logger=None):

--- a/taskflow/engines/worker_based/proxy.py
+++ b/taskflow/engines/worker_based/proxy.py
@@ -19,6 +19,8 @@ import threading
 
 import kombu
 from kombu import exceptions as kombu_exceptions
+from kombu import serialization as kombu_serialization
+from oslo_serialization import jsonutils
 import six
 
 from taskflow.engines.worker_based import dispatcher
@@ -39,6 +41,11 @@ _ConnectionDetails = collections.namedtuple('_ConnectionDetails',
 _TransportDetails = collections.namedtuple('_TransportDetails',
                                            ['options', 'driver_type',
                                             'driver_name', 'driver_version'])
+
+SERIALIZER = 'json'
+
+kombu_serialization.register(SERIALIZER, jsonutils.dumps, jsonutils.loads,
+                             content_type='application/json', content_encoding='utf-8')
 
 
 class Proxy(object):
@@ -175,7 +182,8 @@ class Proxy(object):
                              declare=[queue],
                              type=msg.TYPE,
                              reply_to=reply_to,
-                             correlation_id=correlation_id)
+                             correlation_id=correlation_id,
+                             serializer=SERIALIZER)
 
         def _publish_errback(exc, interval):
             LOG.exception('Publishing error: %s', exc)

--- a/taskflow/engines/worker_based/server.py
+++ b/taskflow/engines/worker_based/server.py
@@ -180,7 +180,7 @@ class Server(object):
                 LOG.warning("Failed to parse request contents"
                             " from message '%s'",
                             ku.DelayedPretty(message), exc_info=True)
-                reply_callback(result=pr.failure_to_dict(failure))
+                reply_callback(result=failure.to_dict())
                 return
 
         # Now fetch the task endpoint (and action handler on it).
@@ -192,7 +192,7 @@ class Server(object):
                             " to continue processing request message '%s'",
                             work.task_cls, ku.DelayedPretty(message),
                             exc_info=True)
-                reply_callback(result=pr.failure_to_dict(failure))
+                reply_callback(result=failure.to_dict())
                 return
         else:
             try:
@@ -203,7 +203,7 @@ class Server(object):
                                 " endpoint '%s', unable to continue processing"
                                 " request message '%s'", work.action, endpoint,
                                 ku.DelayedPretty(message), exc_info=True)
-                    reply_callback(result=pr.failure_to_dict(failure))
+                    reply_callback(result=failure.to_dict())
                     return
             else:
                 try:
@@ -214,7 +214,7 @@ class Server(object):
                                     " message '%s' failed", endpoint,
                                     work.action, ku.DelayedPretty(message),
                                     exc_info=True)
-                        reply_callback(result=pr.failure_to_dict(failure))
+                        reply_callback(result=failure.to_dict())
                         return
                 else:
                     if not reply_callback(state=pr.RUNNING):
@@ -242,7 +242,7 @@ class Server(object):
                 LOG.warning("The '%s' endpoint '%s' execution for request"
                             " message '%s' failed", endpoint, work.action,
                             ku.DelayedPretty(message), exc_info=True)
-                reply_callback(result=pr.failure_to_dict(failure))
+                reply_callback(result=failure.to_dict())
         else:
             # And be done with it!
             if isinstance(result, ft.Failure):

--- a/taskflow/tests/unit/worker_based/test_protocol.py
+++ b/taskflow/tests/unit/worker_based/test_protocol.py
@@ -169,14 +169,6 @@ class TestProtocol(test.TestCase):
             failures={self.task.name: a_failure.to_dict()})
         self.assertEqual(expected, request.to_dict())
 
-    def test_to_dict_with_invalid_json_failures(self):
-        exc = RuntimeError(Unserializable())
-        a_failure = failure.Failure.from_exception(exc)
-        request = self.request(failures={self.task.name: a_failure})
-        expected = self.request_to_dict(
-            failures={self.task.name: a_failure.to_dict(include_args=False)})
-        self.assertEqual(expected, request.to_dict())
-
     @mock.patch('oslo_utils.timeutils.now')
     def test_pending_not_expired(self, now):
         now.return_value = 0


### PR DESCRIPTION
Sometimes exception args are not JSON-serializable, so
force them to be strings as a last-resort. It's more important
that we pass the exception back than its arguments match 100%,
but we try our best.