### PR TITLE
Fix failure exc args encoding

### DIFF
--- a/taskflow/tests/unit/test_failure.py
+++ b/taskflow/tests/unit/test_failure.py
@@ -283,16 +283,6 @@ class FailureObjectTestCase(test.TestCase):
         text = captured.pformat(traceback=True)
         self.assertIn("Traceback (most recent call last):", text)
 
-    def test_no_capture_exc_args(self):
-        captured = _captured_failure(Exception("I am not valid JSON"))
-        fail_obj = failure.Failure(exception_str=captured.exception_str,
-                                   traceback_str=captured.traceback_str,
-                                   exc_type_names=list(captured),
-                                   exc_args=list(captured.exception_args))
-        fail_json = fail_obj.to_dict(include_args=False)
-        self.assertNotEqual(fail_obj.exception_args, fail_json['exc_args'])
-        self.assertEqual(fail_json['exc_args'], tuple())
-
 
 class WrappedFailureTestCase(test.TestCase):
 

--- a/taskflow/tests/unit/worker_based/test_proxy.py
+++ b/taskflow/tests/unit/worker_based/test_proxy.py
@@ -171,7 +171,8 @@ class TestProxy(test.MockTestCase):
                                               correlation_id=task_uuid,
                                               declare=[self.queue_inst_mock],
                                               type=msg_mock.TYPE,
-                                              reply_to=None)
+                                              reply_to=None,
+                                              serializer='json')
         ], routing_key)
         self.master_mock.assert_has_calls(master_mock_calls)
 

--- a/taskflow/types/failure.py
+++ b/taskflow/types/failure.py
@@ -528,7 +528,7 @@ class Failure(mixins.StrMixin):
             'traceback_str': self.traceback_str,
             'exc_type_names': list(self),
             'version': self.DICT_VERSION,
-            'exc_args': [self.safe_encode(arg for arg in self.exception_args)],
+            'exc_args': tuple([self.safe_encode(arg) for arg in self.exception_args]),
             'causes': [f.to_dict() for f in self.causes],
         }
 


### PR DESCRIPTION
A misplaced paren had us encoding a generator instead of the individual args.
Also cleaned up the tests to match the new reality.